### PR TITLE
command-registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+# Code Review
+- When reviewing Pull Requests, focus on the files in the Pull Request and not the overall project.

--- a/lib/gmredis/CMakeLists.txt
+++ b/lib/gmredis/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(gmredis_lib
         src/protocol/parse.cpp
         src/command/command.cpp
         src/command/base_command.cpp
+        src/command/command_registry.cpp
 )
 
 add_library(gmredis::lib ALIAS gmredis_lib)

--- a/lib/gmredis/include/gmredis/command/command_registry.h
+++ b/lib/gmredis/include/gmredis/command/command_registry.h
@@ -7,17 +7,87 @@
 
 namespace gmredis::command {
 
+    /**
+     * @brief Error codes for CommandRegistry operations.
+     */
     enum class CommandRegistryError {
+        /** Attempted to register a command type that is already registered */
         AlreadyRegistered,
+        /** Attempted to retrieve a command type that is not registered */
         CommandNotFound
     };
 
+    /**
+     * @brief Registry interface for managing Redis command implementations.
+     *
+     * The CommandRegistry provides a centralized location for registering and retrieving
+     * Command implementations by their CommandType. It manages the lifetime of registered
+     * commands using shared_ptr for safe, shared ownership.
+     *
+     * Key responsibilities:
+     * - Register command implementations with their corresponding CommandType
+     * - Prevent duplicate registrations for the same CommandType
+     * - Retrieve command implementations by CommandType
+     * - Manage command lifetime through shared ownership
+     *
+     * @note Implementations should be thread-safe if used in a multi-threaded context.
+     *
+     * @example
+     * ```cpp
+     * auto registry = DefaultCommandRegistry();
+     * auto pingCmd = std::make_shared<PingCommand>();
+     *
+     * // Register a command
+     * auto registerResult = registry.registerCommand(CommandType::Ping, pingCmd);
+     * if (registerResult.has_value()) {
+     *     // Handle error: command already registered
+     * }
+     *
+     * // Retrieve a command
+     * auto getResult = registry.getCommand(CommandType::Ping);
+     * if (getResult.has_value()) {
+     *     auto cmd = getResult.value();
+     *     // Use the command...
+     * } else {
+     *     // Handle error: command not found
+     * }
+     * ```
+     */
     class CommandRegistry {
         public:
             virtual ~CommandRegistry() = default;
 
+            /**
+             * @brief Registers a command implementation for a specific CommandType.
+             *
+             * Associates the provided Command implementation with the given CommandType.
+             * The registry shares ownership of the command via shared_ptr. If a command
+             * is already registered for this type, registration fails.
+             *
+             * @param type The CommandType to register the command for
+             * @param cmd Shared pointer to the Command implementation
+             * @return std::nullopt on success, or CommandRegistryError::AlreadyRegistered
+             *         if a command is already registered for this type
+             *
+             * @note This method is noexcept and will not throw exceptions
+             */
             virtual std::optional<CommandRegistryError> registerCommand(CommandType, std::shared_ptr<Command>) noexcept = 0;
 
+            /**
+             * @brief Retrieves a registered command implementation by CommandType.
+             *
+             * Looks up and returns the Command implementation associated with the given
+             * CommandType. Returns a shared_ptr to allow shared ownership of the command.
+             *
+             * @param type The CommandType to retrieve
+             * @return Expected containing a shared_ptr to the Command on success, or
+             *         CommandRegistryError::CommandNotFound if no command is registered
+             *         for this type
+             *
+             * @note This method is noexcept and will not throw exceptions
+             * @note The returned shared_ptr allows multiple callers to safely hold
+             *       references to the same command
+             */
             virtual std::expected<std::shared_ptr<Command>, CommandRegistryError> getCommand(CommandType) noexcept = 0;
     };
 }

--- a/lib/gmredis/include/gmredis/command/command_registry.h
+++ b/lib/gmredis/include/gmredis/command/command_registry.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "gmredis/command/command.h"
+#include <expected>
+#include <optional>
+#include <memory>
+
+namespace gmredis::command {
+
+    enum class CommandRegistryError {
+        AlreadyRegistered,
+        CommandNotFound
+    };
+
+    class CommandRegistry {
+        public:
+            virtual ~CommandRegistry() = default;
+
+            virtual std::optional<CommandRegistryError> registerCommand(CommandType, std::shared_ptr<Command>) noexcept = 0;
+
+            virtual std::expected<std::shared_ptr<Command>, CommandRegistryError> getCommand(CommandType) noexcept = 0;
+    };
+}

--- a/lib/gmredis/include/gmredis/command/command_registry.h
+++ b/lib/gmredis/include/gmredis/command/command_registry.h
@@ -14,7 +14,9 @@ namespace gmredis::command {
         /** Attempted to register a command type that is already registered */
         AlreadyRegistered,
         /** Attempted to retrieve a command type that is not registered */
-        CommandNotFound
+        CommandNotFound,
+        /** If null is passed in when registering a command*/
+        NullCommand,
     };
 
     /**
@@ -88,6 +90,6 @@ namespace gmredis::command {
              * @note The returned shared_ptr allows multiple callers to safely hold
              *       references to the same command
              */
-            virtual std::expected<std::shared_ptr<Command>, CommandRegistryError> getCommand(CommandType) noexcept = 0;
+            virtual std::expected<std::shared_ptr<Command>, CommandRegistryError> getCommand(CommandType) const noexcept = 0;
     };
 }

--- a/lib/gmredis/src/command/command_registry.cpp
+++ b/lib/gmredis/src/command/command_registry.cpp
@@ -1,0 +1,22 @@
+#include "command_registry_impl.h"
+
+namespace gmredis::command {
+
+    std::optional<CommandRegistryError> DefaultCommandRegistry::registerCommand(CommandType commandType, std::shared_ptr<Command> command) noexcept {
+        if (commands.contains(commandType)) {
+            return CommandRegistryError::AlreadyRegistered;
+        }
+
+        commands.insert({commandType, command});
+
+        return std::nullopt;
+    }
+
+    std::expected<std::shared_ptr<Command>, CommandRegistryError> DefaultCommandRegistry::getCommand(CommandType commandType) noexcept {
+        if (!commands.contains(commandType)) {
+            return std::unexpected(CommandRegistryError::CommandNotFound);
+        }
+        return commands.at(commandType);
+    }
+
+}

--- a/lib/gmredis/src/command/command_registry.cpp
+++ b/lib/gmredis/src/command/command_registry.cpp
@@ -3,6 +3,10 @@
 namespace gmredis::command {
 
     std::optional<CommandRegistryError> DefaultCommandRegistry::registerCommand(CommandType commandType, std::shared_ptr<Command> command) noexcept {
+        if (command == nullptr) {
+            return CommandRegistryError::NullCommand;
+        }
+
         if (commands.contains(commandType)) {
             return CommandRegistryError::AlreadyRegistered;
         }
@@ -12,7 +16,7 @@ namespace gmredis::command {
         return std::nullopt;
     }
 
-    std::expected<std::shared_ptr<Command>, CommandRegistryError> DefaultCommandRegistry::getCommand(CommandType commandType) noexcept {
+    std::expected<std::shared_ptr<Command>, CommandRegistryError> DefaultCommandRegistry::getCommand(CommandType commandType) const noexcept {
         if (!commands.contains(commandType)) {
             return std::unexpected(CommandRegistryError::CommandNotFound);
         }

--- a/lib/gmredis/src/command/command_registry_impl.h
+++ b/lib/gmredis/src/command/command_registry_impl.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include "gmredis/command/command_registry.h"
-#include "unordered_map"
+#include <unordered_map>
 
 namespace gmredis::command {
     class DefaultCommandRegistry : public CommandRegistry {
     public:
         std::optional<CommandRegistryError> registerCommand(CommandType commandType, std::shared_ptr<Command> command) noexcept override;
-        std::expected<std::shared_ptr<Command>, CommandRegistryError> getCommand(CommandType commandType) noexcept override;
+        std::expected<std::shared_ptr<Command>, CommandRegistryError> getCommand(CommandType commandType) const noexcept override;
     private:
         std::unordered_map<CommandType, std::shared_ptr<Command>> commands;
     };

--- a/lib/gmredis/src/command/command_registry_impl.h
+++ b/lib/gmredis/src/command/command_registry_impl.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "gmredis/command/command_registry.h"
+#include "unordered_map"
+
+namespace gmredis::command {
+    class DefaultCommandRegistry : public CommandRegistry {
+    public:
+        std::optional<CommandRegistryError> registerCommand(CommandType commandType, std::shared_ptr<Command> command) noexcept override;
+        std::expected<std::shared_ptr<Command>, CommandRegistryError> getCommand(CommandType commandType) noexcept override;
+    private:
+        std::unordered_map<CommandType, std::shared_ptr<Command>> commands;
+    };
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(gmredis_unit_tests
     protocol/parse_test.cpp
     command/command_test.cpp
     command/base_command_test.cpp
+    command/command_registry_test.cpp
 )
 
 target_link_libraries(gmredis_unit_tests

--- a/tests/unit/command/command_registry_test.cpp
+++ b/tests/unit/command/command_registry_test.cpp
@@ -26,6 +26,14 @@ namespace gmredis::test {
         ASSERT_EQ(returnedCmd.value(), cmd);
     }
 
+    TEST(CommandRegistryTest, NullCommandRegistration) {
+        auto registry = command::DefaultCommandRegistry();
+        auto result = registry.registerCommand(command::CommandType::Ping, nullptr);
+
+        ASSERT_TRUE(result.has_value());
+        ASSERT_EQ(result.value(), command::CommandRegistryError::NullCommand);
+    }
+
     TEST(CommandRegistryTest, AlreadyRegistered) {
         auto registry = command::DefaultCommandRegistry();
         auto cmd = std::make_shared<TestCommand>();
@@ -44,6 +52,24 @@ namespace gmredis::test {
         auto result = registry.getCommand(command::CommandType::Ping);
         ASSERT_FALSE(result.has_value());
         ASSERT_EQ(result.error(), command::CommandRegistryError::CommandNotFound);
-
     }
+
+    TEST(CommandRegistryTest, MultiRegistrationAndGet) {
+        auto registry = command::DefaultCommandRegistry();
+        auto cmd1 = std::make_shared<TestCommand>();
+        auto cmd2 = std::make_shared<TestCommand>();
+
+        auto result = registry.registerCommand(command::CommandType::Ping, cmd1);
+        ASSERT_FALSE(result.has_value());
+
+        result = registry.registerCommand(command::CommandType::Get, cmd2);
+        ASSERT_FALSE(result.has_value());
+
+        auto returnedCmd1 = registry.getCommand(command::CommandType::Ping);
+        auto returnedCmd2 = registry.getCommand(command::CommandType::Get);
+
+        ASSERT_EQ(returnedCmd1.value(), cmd1);
+        ASSERT_EQ(returnedCmd2.value(), cmd2);
+    }
+
 }

--- a/tests/unit/command/command_registry_test.cpp
+++ b/tests/unit/command/command_registry_test.cpp
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+#include "gmredis/command/command.h"
+#include "command/command_registry_impl.h"
+
+namespace gmredis::test {
+    class TestCommand : public command::Command {
+    public:
+        std::optional<command::CommandError> validate(const protocol::Array&) override {
+            return std::nullopt;  // Always valid
+        }
+
+        std::expected<protocol::RespValue, command::CommandError> execute(const protocol::Array&) override {
+            return protocol::SimpleString("OK");  // Simple stub response
+        }
+    };
+
+    TEST(CommandRegistryTest, RegisterAndGetOK) {
+        auto registry = command::DefaultCommandRegistry();
+        auto cmd = std::make_shared<TestCommand>();
+
+        auto result = registry.registerCommand(command::CommandType::Ping, cmd);
+        ASSERT_FALSE(result.has_value());
+
+        auto returnedCmd = registry.getCommand(command::CommandType::Ping);
+        ASSERT_TRUE(returnedCmd.has_value());
+        ASSERT_EQ(returnedCmd.value(), cmd);
+    }
+
+    TEST(CommandRegistryTest, AlreadyRegistered) {
+        auto registry = command::DefaultCommandRegistry();
+        auto cmd = std::make_shared<TestCommand>();
+        auto result = registry.registerCommand(command::CommandType::Ping, cmd);
+
+        ASSERT_FALSE(result.has_value());
+
+        auto duplicateCmd = std::make_shared<TestCommand>();
+        auto duplicateResult = registry.registerCommand(command::CommandType::Ping, duplicateCmd);
+        ASSERT_TRUE(duplicateResult.has_value());
+        ASSERT_EQ(duplicateResult.value(), command::CommandRegistryError::AlreadyRegistered);
+    }
+
+    TEST(CommandRegistryTest, CommandNotFound) {
+        auto registry = command::DefaultCommandRegistry();
+        auto result = registry.getCommand(command::CommandType::Ping);
+        ASSERT_FALSE(result.has_value());
+        ASSERT_EQ(result.error(), command::CommandRegistryError::CommandNotFound);
+
+    }
+}


### PR DESCRIPTION
creates the CommandRegistry interface and a default implementation.

Closes #21